### PR TITLE
プロトタイプ 編集機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -21,6 +21,12 @@ class PrototypesController < ApplicationController
     @prototype = Prototype.find(params[:id])
   end
 
+  def edit
+  end
+
+  def update
+  end
+
   private
 
   def prototype_params

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -22,9 +22,16 @@ class PrototypesController < ApplicationController
   end
 
   def edit
+    @prototype = Prototype.find(params[:id])
   end
 
   def update
+    @prototype = Prototype.find(params[:id])
+    if @prototype.update(prototype_params)
+      redirect_to prototype_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/views/prototypes/edit.html.erb
+++ b/app/views/prototypes/edit.html.erb
@@ -3,6 +3,7 @@
     <div class="form__wrapper">
       <h2 class="page-heading">プロトタイプ編集</h2>
       <%# 部分テンプレートでフォームを表示する %>
+      <%= render partial: "form", locals: { prototype: @prototype } %>
     </div>
   </div>
 </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -8,7 +8,7 @@
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
         <% if user_signed_in? && current_user.id == @prototype.user_id %>
           <div class="prototype__manage">
-            <%= link_to "編集する", root_path, class: :prototype__btn %>
+            <%= link_to "編集する", edit_prototype_path, class: :prototype__btn %>
             <%= link_to "削除する", root_path, class: :prototype__btn %>
           </div>
         <% end %>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -6,10 +6,12 @@
       </p>
       <%= link_to @prototype.user.name, root_path, class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
-        <div class="prototype__manage">
-          <%= link_to "編集する", root_path, class: :prototype__btn %>
-          <%= link_to "削除する", root_path, class: :prototype__btn %>
-        </div>
+        <% if user_signed_in? && current_user.id == @prototype.user_id %>
+          <div class="prototype__manage">
+            <%= link_to "編集する", root_path, class: :prototype__btn %>
+            <%= link_to "削除する", root_path, class: :prototype__btn %>
+          </div>
+        <% end %>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
       <div class="prototype__image">
         <%= image_tag @prototype.image, class: 'card__img' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   # root "articles#index"
   root to: "prototypes#index"
 #     プロトタイプ-詳細機能
-  resources :prototypes, only: [:index, :new, :create, :show]
+  resources :prototypes, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
what
投稿編集機能の実装
①投稿主のみに表示される編集ボタン
②各関連ページのリンク付
③コントローラとビュー
④失敗時にフォーム内に入力された情報を保持しつつrenderメソッドで編集ページから遷移しない設定
why
投稿主のみ編集が可能かつ、データの上書きを可能にするため