### PR TITLE
プロトタイプ削除機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -34,6 +34,9 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def destroy
+  end
+
   private
 
   def prototype_params

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -35,6 +35,12 @@ class PrototypesController < ApplicationController
   end
 
   def destroy
+    @prototype = Prototype.find(params[:id])
+    if @prototype.destroy
+      redirect_to root_path, notice: '投稿を削除しました。'
+    else
+      redirect_to prototype_path(@prototype), alert: '削除に失敗しました。'
+    end
   end
 
   private

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -9,7 +9,7 @@
         <% if user_signed_in? && current_user.id == @prototype.user_id %>
           <div class="prototype__manage">
             <%= link_to "編集する", edit_prototype_path, class: :prototype__btn %>
-            <%= link_to "削除する", root_path, class: :prototype__btn %>
+            <%= link_to "削除する", prototype_path(@prototype), data: { turbo_method: :delete, confirm: "本当に削除しますか？" }, class: :prototype__btn %>
           </div>
         <% end %>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   # root "articles#index"
   root to: "prototypes#index"
 #     プロトタイプ-詳細機能
-  resources :prototypes, only: [:index, :new, :create, :show, :edit, :update]
+  resources :prototypes
 end


### PR DESCRIPTION
what 
プロトタイプ削除機能を投稿主のみの画面に実装。
why
ユーザーの希望で投稿の削除を行えるようにするため